### PR TITLE
Get Repository by Name and Print Metadata Methods and Demo Added

### DIFF
--- a/gdettt/src/main/java/org/compass/gdet/GitHubAPIDemo.java
+++ b/gdettt/src/main/java/org/compass/gdet/GitHubAPIDemo.java
@@ -1,14 +1,20 @@
 package org.compass.gdet;
+import org.kohsuke.github.*;
+import java.util.List;
 
 public class GitHubAPIDemo {
   public static void main( String[] args ) {
     System.out.println("GitHub Data Extration Tool Demo");
     GithubDataExtractionTool git = new GithubDataExtractionTool();
-    if (git.checkConnection()) {
-      System.out.println("Successfully Established Connection");
-    }
-    else {
+    if (!git.checkConnection()) {
       System.out.println("Error Establishing Connection");
+    }
+    System.out.println("Successfully Established Connection");
+    GHRepository repo = git.getRepository(
+      "CompassSoftware/GDET-Tremendous-Trio");
+    if (repo != null) {
+      System.out.printf("Repository: %s\n", repo.getName());
+      System.out.printf("Owned by: %s\n", repo.getOwnerName());
     }
   }
 }

--- a/gdettt/src/main/java/org/compass/gdet/GitHubAPIDemo.java
+++ b/gdettt/src/main/java/org/compass/gdet/GitHubAPIDemo.java
@@ -13,8 +13,7 @@ public class GitHubAPIDemo {
     GHRepository repo = git.getRepository(
       "CompassSoftware/GDET-Tremendous-Trio");
     if (repo != null) {
-      System.out.printf("Repository: %s\n", repo.getName());
-      System.out.printf("Owned by: %s\n", repo.getOwnerName());
+      System.out.print(GithubDataExtractionTool.getRepositoryMetaData(repo));
     }
   }
 }

--- a/gdettt/src/main/java/org/compass/gdet/GithubDataExtractionTool.java
+++ b/gdettt/src/main/java/org/compass/gdet/GithubDataExtractionTool.java
@@ -1,11 +1,17 @@
 package org.compass.gdet;
 import org.kohsuke.github.*;
 import java.io.IOException;
+import java.util.List;
 
 public class GithubDataExtractionTool
 {
   private GitHub github;
 
+  /**Constructor
+  * This constructor will try to establish a connection to gthub with the
+  * username and password held in ~/.github and will print an error message
+  * if it is unable to.
+  */
   public GithubDataExtractionTool()
   {
     try {
@@ -16,6 +22,13 @@ public class GithubDataExtractionTool
     }
   }
 
+  /**checkConnection
+  * This method will check the connection to github and will return false if a
+  * connection has not been established.
+  *
+  * @return:
+  *   boolean - true if connection exists, false if not.
+  */
   public boolean checkConnection() {
     try {
       if (github != null) {
@@ -28,6 +41,26 @@ public class GithubDataExtractionTool
     }
     catch (IOException e) {
       return false;
+    }
+  }
+
+  /**getRepository
+  * This method will try to get a repository with the name <reponame> and return
+  * a GHRepository object if successful or null if not.
+  *
+  * @params:
+  *   reponame - the string name of a repo in the standard github format
+  *     <username>/<reponame>
+  *
+  * @return:
+  *   GHRepository - a Github repository object if successful, null if not.
+  */
+  public GHRepository getRepository(String reponame) {
+    try {
+      return github.getRepository(reponame);
+    }
+    catch (IOException e) {
+      return null;
     }
   }
 }

--- a/gdettt/src/main/java/org/compass/gdet/GithubDataExtractionTool.java
+++ b/gdettt/src/main/java/org/compass/gdet/GithubDataExtractionTool.java
@@ -56,11 +56,32 @@ public class GithubDataExtractionTool
   *   GHRepository - a Github repository object if successful, null if not.
   */
   public GHRepository getRepository(String reponame) {
+    assert(checkConnection());
     try {
       return github.getRepository(reponame);
     }
     catch (IOException e) {
       return null;
     }
+  }
+
+  /**getRepositoryMetaData
+  * This method will return a string representation of the repository's details.
+  *
+  * @params:
+  *   repo - a GHRepository object to get metadata from
+  *
+  * @return:
+  *   string - a foratted stirng representation of the repo's metadata
+  */
+  public static String getRepositoryMetaData(GHRepository repo) {
+    String response = "";
+    response += String.format("%32s\n", "").replace(" ", "-");
+    if (repo != null) {
+      response += repo.getName() + "\n";
+      response += String.format("Owned by: %s\n", repo.getOwnerName());
+    }
+    response += String.format("%32s\n", "").replace(" ", "-");
+    return response;
   }
 }

--- a/gdettt/src/test/java/org/compass/gdet/GithubDataExtractionToolTest.java
+++ b/gdettt/src/test/java/org/compass/gdet/GithubDataExtractionToolTest.java
@@ -1,5 +1,6 @@
 package org.compass.gdet;
 
+import org.kohsuke.github.*;
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,5 +27,37 @@ public class GithubDataExtractionToolTest
   public void shouldHaveAValidConnection() {
     GithubDataExtractionTool gdet = new GithubDataExtractionTool();
     assertTrue(gdet.checkConnection());
+  }
+
+  /*
+  * A basic test for our getRepository method.  Should return a valid repository
+  * for this repository.
+  */
+  @Test
+  public void shouldReturnAValidRepository() {
+    GithubDataExtractionTool gdet = new GithubDataExtractionTool();
+    GHRepository repo =
+      gdet.getRepository("CompassSoftware/GDET-Tremendous-Trio");
+    assertTrue(repo != null);
+    assertTrue(repo instanceof GHRepository);
+    assertTrue(repo.getName().equals("GDET-Tremendous-Trio"));
+    assertTrue(repo.getOwnerName().equals("CompassSoftware"));
+  }
+
+  /*
+  * A basic test for our getRepositoryMetaData method.  Should return a
+  * formatted metadata string for this repository.
+  */
+  @Test
+  public void shouldReturnACorrectlyFormattedString() {
+    GithubDataExtractionTool gdet = new GithubDataExtractionTool();
+    GHRepository repo =
+      gdet.getRepository("CompassSoftware/GDET-Tremendous-Trio");
+    String expectedOutput = "--------------------------------\n" +
+      "GDET-Tremendous-Trio\n" +
+      "Owned by: CompassSoftware\n" +
+      "--------------------------------\n";
+    assertTrue(GithubDataExtractionTool.getRepositoryMetaData(repo).equals(
+      expectedOutput));
   }
 }


### PR DESCRIPTION
We now have a method to get a repository by its name, a static method to take a repository object and return a formatted string representing its metadata, and tests and demos for each!  